### PR TITLE
Fix `Lines` to use `__new__`

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (thonny-restrict-write) (2)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (thonny-sealed)" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/thonny-restrict-write.iml
+++ b/.idea/thonny-restrict-write.iml
@@ -7,7 +7,7 @@
       <excludeFolder url="file://$MODULE_DIR$/thonny_sealed.egg-info" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.8 (thonny-restrict-write) (2)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.8 (thonny-sealed)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 thonny>=3.0.0,<4
-icontract>=2.5.0
+icontract>=2.5.1

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setuptools.setup(
             "docutils>=0.14,<1",
             "icontract>=2.5.0",
             "prettytable>=2.1.0,<3",
-            "icontract-hypothesis>=1.1.1,<2"
+            "icontract-hypothesis>=1.1.2,<2"
         ],
     },
     package_data={"thonnycontrib.thonny_sealed": ["py.typed"]},

--- a/tests/test_tag_logic.py
+++ b/tests/test_tag_logic.py
@@ -425,15 +425,6 @@ class Test_delete_against_a_naive_implementation(unittest.TestCase):
 
 
 class Test_with_icontract_hypothesis(unittest.TestCase):
-    lines_strategy = icontract_hypothesis.infer_strategy(
-        thonnycontrib.thonny_sealed.assert_lines
-    ).map(lambda d: thonnycontrib.thonny_sealed.assert_lines(**d))
-
-    hypothesis.strategies.register_type_strategy(
-        thonnycontrib.thonny_sealed.Lines,  # type: ignore
-        lines_strategy
-    )
-
     def test_extract_markers(self) -> None:
         icontract_hypothesis.test_with_inferred_strategy(
             thonnycontrib.thonny_sealed.extract_markers

--- a/tests/test_thonny_seal.py
+++ b/tests/test_thonny_seal.py
@@ -123,7 +123,7 @@ class Test_on_valid_examples(unittest.TestCase):
             )
         ]
         for text, expected_text, identifier in table:
-            lines = thonnycontrib.thonny_sealed.assert_lines(text.splitlines())
+            lines = thonnycontrib.thonny_sealed.Lines(text.splitlines())
 
             got_lines, err = main.seal(lines=lines)
             self.assertIsNone(err, identifier)
@@ -180,7 +180,7 @@ class Test_invalid_cases(unittest.TestCase):
         ]
 
         for text, expected_error, identifier in table:
-            lines = thonnycontrib.thonny_sealed.assert_lines(text.splitlines())
+            lines = thonnycontrib.thonny_sealed.Lines(text.splitlines())
 
             got_lines, err = main.seal(lines=lines)
             self.assertIsNotNone(err, identifier)

--- a/thonnycontrib/thonny_sealed/thonny_seal/main.py
+++ b/thonnycontrib/thonny_sealed/thonny_seal/main.py
@@ -105,7 +105,7 @@ def seal(
 
     result.extend(lines[blocks[-1].last.lineno + 1 :])
 
-    return thonnycontrib.thonny_sealed.assert_lines(lines=result), None
+    return thonnycontrib.thonny_sealed.Lines(lines=result), None
 
 
 def run(args: Args, stdout: TextIO, stderr: TextIO) -> int:
@@ -119,7 +119,7 @@ def run(args: Args, stdout: TextIO, stderr: TextIO) -> int:
         return 1
 
     content = args.input_path.read_text(encoding="utf-8")
-    lines = thonnycontrib.thonny_sealed.assert_lines(content.splitlines())
+    lines = thonnycontrib.thonny_sealed.Lines(content.splitlines())
     sealed_lines, error = seal(lines=lines)
     if error:
         stderr.write(


### PR DESCRIPTION
This patch makes `Lines` use the `__new__` method so that the class can
be readily tested with icontract-hypothesis without any additional
boiler-plate code.