### PR TITLE
Mark start and end comments

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/test_data/tags/consecutive_seals/tags.txt
+++ b/test_data/tags/consecutive_seals/tags.txt
@@ -1,5 +1,5 @@
-Index        Char        Tag starts           Tag ends
-1.0          '#'         thonny_sealed
+Index        Char        Tag starts                                Tag ends
+1.0          '#'         thonny_sealed, thonny_sealed_start
 1.1          ' '
 1.2          's'
 1.3          'e'
@@ -21,7 +21,7 @@ Index        Char        Tag starts           Tag ends
 1.19         'a'
 1.20         '0'
 1.21         '\n'
-2.0          's'
+2.0          's'                                                   thonny_sealed_start
 2.1          'o'
 2.2          'm'
 2.3          'e'
@@ -31,7 +31,7 @@ Index        Char        Tag starts           Tag ends
 2.7          'n'
 2.8          'g'
 2.9          '\n'
-3.0          '#'
+3.0          '#'         thonny_sealed_end
 3.1          ' '
 3.2          's'
 3.3          'e'
@@ -53,8 +53,8 @@ Index        Char        Tag starts           Tag ends
 3.19         '7'
 3.20         'a'
 3.21         '0'
-3.22         '\n'                             thonny_sealed
-4.0          '#'         thonny_sealed
+3.22         '\n'                                                  thonny_sealed
+4.0          '#'         thonny_sealed, thonny_sealed_start        thonny_sealed_end
 4.1          ' '
 4.2          's'
 4.3          'e'
@@ -76,7 +76,7 @@ Index        Char        Tag starts           Tag ends
 4.19         'f'
 4.20         '9'
 4.21         '\n'
-5.0          's'
+5.0          's'                                                   thonny_sealed_start
 5.1          'o'
 5.2          'm'
 5.3          'e'
@@ -91,7 +91,7 @@ Index        Char        Tag starts           Tag ends
 5.12         's'
 5.13         'e'
 5.14         '\n'
-6.0          '#'
+6.0          '#'         thonny_sealed_end
 6.1          ' '
 6.2          's'
 6.3          'e'
@@ -113,5 +113,5 @@ Index        Char        Tag starts           Tag ends
 6.19         'd'
 6.20         'f'
 6.21         '9'
-6.22         '\n'                             thonny_sealed
-end          ''
+6.22         '\n'                                                  thonny_sealed
+end          ''                                                    thonny_sealed_end

--- a/test_data/tags/indention/tags.txt
+++ b/test_data/tags/indention/tags.txt
@@ -1,5 +1,5 @@
-Index        Char        Tag starts           Tag ends
-1.0          '#'         thonny_sealed
+Index        Char        Tag starts                                Tag ends
+1.0          '#'         thonny_sealed, thonny_sealed_start
 1.1          ' '
 1.2          's'
 1.3          'e'
@@ -21,7 +21,7 @@ Index        Char        Tag starts           Tag ends
 1.19         '7'
 1.20         'd'
 1.21         '\n'
-2.0          'A'
+2.0          'A'                                                   thonny_sealed_start
 2.1          '\n'
 3.0          ' '
 3.1          ' '
@@ -29,7 +29,7 @@ Index        Char        Tag starts           Tag ends
 3.3          ' '
 3.4          'B'
 3.5          '\n'
-4.0          ' '
+4.0          ' '         thonny_sealed_end
 4.1          ' '
 4.2          ' '
 4.3          ' '
@@ -55,15 +55,15 @@ Index        Char        Tag starts           Tag ends
 4.23         '1'
 4.24         '7'
 4.25         'd'
-4.26         '\n'                             thonny_sealed
-5.0          ' '
+4.26         '\n'                                                  thonny_sealed
+5.0          ' '                                                   thonny_sealed_end
 5.1          ' '
 5.2          ' '
 5.3          ' '
 5.4          'C'
 5.5          '\n'
 6.0          '\n'
-7.0          '#'         thonny_sealed
+7.0          '#'         thonny_sealed, thonny_sealed_start
 7.1          ' '
 7.2          's'
 7.3          'e'
@@ -85,7 +85,7 @@ Index        Char        Tag starts           Tag ends
 7.19         '7'
 7.20         '6'
 7.21         '\n'
-8.0          'D'
+8.0          'D'                                                   thonny_sealed_start
 8.1          '\n'
 9.0          ' '
 9.1          ' '
@@ -93,7 +93,7 @@ Index        Char        Tag starts           Tag ends
 9.3          ' '
 9.4          'E'
 9.5          '\n'
-10.0         ' '
+10.0         ' '         thonny_sealed_end
 10.1         ' '
 10.2         ' '
 10.3         ' '
@@ -119,5 +119,5 @@ Index        Char        Tag starts           Tag ends
 10.23        'f'
 10.24        '7'
 10.25        '6'
-10.26        '\n'                             thonny_sealed
-end          ''
+10.26        '\n'                                                  thonny_sealed
+end          ''                                                    thonny_sealed_end

--- a/test_data/tags/newline_seal_newline/tags.txt
+++ b/test_data/tags/newline_seal_newline/tags.txt
@@ -1,6 +1,6 @@
-Index        Char        Tag starts           Tag ends
+Index        Char        Tag starts                                Tag ends
 1.0          '\n'
-2.0          '#'         thonny_sealed
+2.0          '#'         thonny_sealed, thonny_sealed_start
 2.1          ' '
 2.2          's'
 2.3          'e'
@@ -22,7 +22,7 @@ Index        Char        Tag starts           Tag ends
 2.19         '9'
 2.20         '4'
 2.21         '\n'
-3.0          '#'
+3.0          '#'         thonny_sealed_end                         thonny_sealed_start
 3.1          ' '
 3.2          's'
 3.3          'e'
@@ -44,8 +44,8 @@ Index        Char        Tag starts           Tag ends
 3.19         '2'
 3.20         '9'
 3.21         '4'
-3.22         '\n'                             thonny_sealed
-4.0          's'
+3.22         '\n'                                                  thonny_sealed
+4.0          's'                                                   thonny_sealed_end
 4.1          'o'
 4.2          'm'
 4.3          'e'
@@ -56,7 +56,7 @@ Index        Char        Tag starts           Tag ends
 4.8          't'
 4.9          '\n'
 5.0          '\n'
-6.0          '#'         thonny_sealed
+6.0          '#'         thonny_sealed, thonny_sealed_start
 6.1          ' '
 6.2          's'
 6.3          'e'
@@ -78,7 +78,7 @@ Index        Char        Tag starts           Tag ends
 6.19         'b'
 6.20         '4'
 6.21         '\n'
-7.0          '#'
+7.0          '#'         thonny_sealed_end                         thonny_sealed_start
 7.1          ' '
 7.2          's'
 7.3          'e'
@@ -100,8 +100,8 @@ Index        Char        Tag starts           Tag ends
 7.19         'e'
 7.20         'b'
 7.21         '4'
-7.22         '\n'                             thonny_sealed
-8.0          '\n'
+7.22         '\n'                                                  thonny_sealed
+8.0          '\n'                                                  thonny_sealed_end
 9.0          'a'
 9.1          'n'
 9.2          'o'
@@ -115,7 +115,7 @@ Index        Char        Tag starts           Tag ends
 9.10         'x'
 9.11         't'
 9.12         '\n'
-10.0         '#'         thonny_sealed
+10.0         '#'         thonny_sealed, thonny_sealed_start
 10.1         ' '
 10.2         's'
 10.3         'e'
@@ -137,7 +137,7 @@ Index        Char        Tag starts           Tag ends
 10.19        'd'
 10.20        '6'
 10.21        '\n'
-11.0         '#'
+11.0         '#'         thonny_sealed_end                         thonny_sealed_start
 11.1         ' '
 11.2         's'
 11.3         'e'
@@ -159,6 +159,6 @@ Index        Char        Tag starts           Tag ends
 11.19        'f'
 11.20        'd'
 11.21        '6'
-11.22        '\n'                             thonny_sealed
-12.0         '\n'
+11.22        '\n'                                                  thonny_sealed
+12.0         '\n'                                                  thonny_sealed_end
 end          ''

--- a/test_data/tags/no_content_but_sealing_comments/tags.txt
+++ b/test_data/tags/no_content_but_sealing_comments/tags.txt
@@ -1,5 +1,5 @@
-Index        Char        Tag starts           Tag ends
-1.0          '#'         thonny_sealed
+Index        Char        Tag starts                                Tag ends
+1.0          '#'         thonny_sealed, thonny_sealed_start
 1.1          ' '
 1.2          's'
 1.3          'e'
@@ -21,7 +21,7 @@ Index        Char        Tag starts           Tag ends
 1.19         '9'
 1.20         '4'
 1.21         '\n'
-2.0          '#'
+2.0          '#'         thonny_sealed_end                         thonny_sealed_start
 2.1          ' '
 2.2          's'
 2.3          'e'
@@ -43,6 +43,6 @@ Index        Char        Tag starts           Tag ends
 2.19         '2'
 2.20         '9'
 2.21         '4'
-2.22         '\n'                             thonny_sealed
-3.0          '\n'
+2.22         '\n'                                                  thonny_sealed
+3.0          '\n'                                                  thonny_sealed_end
 end          ''

--- a/test_data/tags/sealed_in_the_middle/tags.txt
+++ b/test_data/tags/sealed_in_the_middle/tags.txt
@@ -1,4 +1,4 @@
-Index        Char        Tag starts           Tag ends
+Index        Char        Tag starts                                Tag ends
 1.0          'P'
 1.1          'r'
 1.2          'e'
@@ -6,7 +6,7 @@ Index        Char        Tag starts           Tag ends
 1.4          'i'
 1.5          'x'
 1.6          '\n'
-2.0          '#'         thonny_sealed
+2.0          '#'         thonny_sealed, thonny_sealed_start
 2.1          ' '
 2.2          's'
 2.3          'e'
@@ -28,14 +28,14 @@ Index        Char        Tag starts           Tag ends
 2.19         '3'
 2.20         'c'
 2.21         '\n'
-3.0          'M'
+3.0          'M'                                                   thonny_sealed_start
 3.1          'i'
 3.2          'd'
 3.3          'd'
 3.4          'l'
 3.5          'e'
 3.6          '\n'
-4.0          '#'
+4.0          '#'         thonny_sealed_end
 4.1          ' '
 4.2          's'
 4.3          'e'
@@ -57,8 +57,8 @@ Index        Char        Tag starts           Tag ends
 4.19         'b'
 4.20         '3'
 4.21         'c'
-4.22         '\n'                             thonny_sealed
-5.0          'S'
+4.22         '\n'                                                  thonny_sealed
+5.0          'S'                                                   thonny_sealed_end
 5.1          'u'
 5.2          'f'
 5.3          'f'

--- a/test_data/tags/sealed_prefix_with_sealed_content_and_unsealed_suffix/tags.txt
+++ b/test_data/tags/sealed_prefix_with_sealed_content_and_unsealed_suffix/tags.txt
@@ -1,5 +1,5 @@
-Index        Char        Tag starts           Tag ends
-1.0          '#'         thonny_sealed
+Index        Char        Tag starts                                Tag ends
+1.0          '#'         thonny_sealed, thonny_sealed_start
 1.1          ' '
 1.2          's'
 1.3          'e'
@@ -21,7 +21,7 @@ Index        Char        Tag starts           Tag ends
 1.19         '0'
 1.20         '5'
 1.21         '\n'
-2.0          'S'
+2.0          'S'                                                   thonny_sealed_start
 2.1          'o'
 2.2          'm'
 2.3          'e'
@@ -31,7 +31,7 @@ Index        Char        Tag starts           Tag ends
 2.7          'n'
 2.8          'g'
 2.9          '\n'
-3.0          '#'
+3.0          '#'         thonny_sealed_end
 3.1          ' '
 3.2          's'
 3.3          'e'
@@ -53,8 +53,8 @@ Index        Char        Tag starts           Tag ends
 3.19         '8'
 3.20         '0'
 3.21         '5'
-3.22         '\n'                             thonny_sealed
-4.0          'M'
+3.22         '\n'                                                  thonny_sealed
+4.0          'M'                                                   thonny_sealed_end
 4.1          'o'
 4.2          'r'
 4.3          'e'

--- a/test_data/tags/sealed_suffix/tags.txt
+++ b/test_data/tags/sealed_suffix/tags.txt
@@ -1,4 +1,4 @@
-Index        Char        Tag starts           Tag ends
+Index        Char        Tag starts                                Tag ends
 1.0          'P'
 1.1          'r'
 1.2          'e'
@@ -6,7 +6,7 @@ Index        Char        Tag starts           Tag ends
 1.4          'i'
 1.5          'x'
 1.6          '\n'
-2.0          '#'         thonny_sealed
+2.0          '#'         thonny_sealed, thonny_sealed_start
 2.1          ' '
 2.2          's'
 2.3          'e'
@@ -28,14 +28,14 @@ Index        Char        Tag starts           Tag ends
 2.19         '9'
 2.20         '3'
 2.21         '\n'
-3.0          'S'
+3.0          'S'                                                   thonny_sealed_start
 3.1          'u'
 3.2          'f'
 3.3          'f'
 3.4          'i'
 3.5          'x'
 3.6          '\n'
-4.0          '#'
+4.0          '#'         thonny_sealed_end
 4.1          ' '
 4.2          's'
 4.3          'e'
@@ -57,6 +57,6 @@ Index        Char        Tag starts           Tag ends
 4.19         'c'
 4.20         '9'
 4.21         '3'
-4.22         '\n'                             thonny_sealed
-5.0          '\n'
+4.22         '\n'                                                  thonny_sealed
+5.0          '\n'                                                  thonny_sealed_end
 end          ''

--- a/test_data/tags/three_sealed_areas_in_sandwich/tags.txt
+++ b/test_data/tags/three_sealed_areas_in_sandwich/tags.txt
@@ -1,7 +1,7 @@
-Index        Char        Tag starts           Tag ends
+Index        Char        Tag starts                                Tag ends
 1.0          'a'
 1.1          '\n'
-2.0          '#'         thonny_sealed
+2.0          '#'         thonny_sealed, thonny_sealed_start
 2.1          ' '
 2.2          's'
 2.3          'e'
@@ -23,14 +23,14 @@ Index        Char        Tag starts           Tag ends
 2.19         'b'
 2.20         '3'
 2.21         '\n'
-3.0          't'
+3.0          't'                                                   thonny_sealed_start
 3.1          'e'
 3.2          'x'
 3.3          't'
 3.4          ' '
 3.5          'b'
 3.6          '\n'
-4.0          '#'
+4.0          '#'         thonny_sealed_end
 4.1          ' '
 4.2          's'
 4.3          'e'
@@ -52,15 +52,15 @@ Index        Char        Tag starts           Tag ends
 4.19         '2'
 4.20         'b'
 4.21         '3'
-4.22         '\n'                             thonny_sealed
-5.0          't'
+4.22         '\n'                                                  thonny_sealed
+5.0          't'                                                   thonny_sealed_end
 5.1          'e'
 5.2          'x'
 5.3          't'
 5.4          ' '
 5.5          'c'
 5.6          '\n'
-6.0          '#'         thonny_sealed
+6.0          '#'         thonny_sealed, thonny_sealed_start
 6.1          ' '
 6.2          's'
 6.3          'e'
@@ -82,14 +82,14 @@ Index        Char        Tag starts           Tag ends
 6.19         'd'
 6.20         '8'
 6.21         '\n'
-7.0          't'
+7.0          't'                                                   thonny_sealed_start
 7.1          'e'
 7.2          'x'
 7.3          't'
 7.4          ' '
 7.5          'd'
 7.6          '\n'
-8.0          '#'
+8.0          '#'         thonny_sealed_end
 8.1          ' '
 8.2          's'
 8.3          'e'
@@ -111,15 +111,15 @@ Index        Char        Tag starts           Tag ends
 8.19         'b'
 8.20         'd'
 8.21         '8'
-8.22         '\n'                             thonny_sealed
-9.0          't'
+8.22         '\n'                                                  thonny_sealed
+9.0          't'                                                   thonny_sealed_end
 9.1          'e'
 9.2          'x'
 9.3          't'
 9.4          ' '
 9.5          'e'
 9.6          '\n'
-10.0         '#'         thonny_sealed
+10.0         '#'         thonny_sealed, thonny_sealed_start
 10.1         ' '
 10.2         's'
 10.3         'e'
@@ -141,14 +141,14 @@ Index        Char        Tag starts           Tag ends
 10.19        'f'
 10.20        '6'
 10.21        '\n'
-11.0         't'
+11.0         't'                                                   thonny_sealed_start
 11.1         'e'
 11.2         'x'
 11.3         't'
 11.4         ' '
 11.5         'f'
 11.6         '\n'
-12.0         '#'
+12.0         '#'         thonny_sealed_end
 12.1         ' '
 12.2         's'
 12.3         'e'
@@ -170,8 +170,8 @@ Index        Char        Tag starts           Tag ends
 12.19        '5'
 12.20        'f'
 12.21        '6'
-12.22        '\n'                             thonny_sealed
-13.0         't'
+12.22        '\n'                                                  thonny_sealed
+13.0         't'                                                   thonny_sealed_end
 13.1         'e'
 13.2         'x'
 13.3         't'


### PR DESCRIPTION
This patch changes the visual appearance of the start and end comment so
that the sealed block is easier to read.